### PR TITLE
adminのgenre/index, editとitem/new機能追加

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,14 +1,28 @@
 class Admin::GenresController < ApplicationController
+
   def index
+    @genres = Genre.all
+    @genre = Genre.new
   end
 
   def create
+    @genre = Genre.new(genre_params)
+    @genre.save
+    redirect_to admin_genres_path
   end
 
   def edit
+    @genre = Genre.find(params[:id])
   end
 
   def update
+    @genre = Genre.find(params[:id])
+    @genre.update(genre_params)
+    redirect_to admin_genres_path
   end
 
+  private
+  def genre_params
+    params.require(:genre).permit(:name)
+  end
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -3,18 +3,30 @@ class Admin::ItemsController < ApplicationController
   end
 
   def new
+    @item = Item.new
+    @genre = Genre.all
   end
 
   def create
+    @item = Item.new(item_params)
+    @item.save
+    redirect_to admin_item_path(@item)
   end
 
   def show
+    @item = Item.find(params[:id])
+
   end
 
   def edit
   end
 
   def update
+  end
+
+  private
+  def item_params
+    params.require(:item).permit(:name, :intro, :tax_free_price, :sale_status, :genre_id, :image)
   end
 
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,2 +1,3 @@
 class Genre < ApplicationRecord
+  has_many :items, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,6 @@
 class Item < ApplicationRecord
+  belongs_to :genre
+
+  has_one_attached :image
+
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,2 +1,7 @@
-<h1>Admin::Genres#edit</h1>
-<p>Find me in app/views/admin/genres/edit.html.erb</p>
+<h2>ジャンル編集<h2>
+
+<%= form_with model: @genre, url: admin_genre_path(@genre.id), method: :patch, local: true do |f| %>
+<h4>ジャンル名<h4>
+<%= f.text_field :name %>
+<%= f.submit '変更を保存' %>
+<% end %>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,2 +1,13 @@
-<h1>Admin::Genres#index</h1>
-<p>Find me in app/views/admin/genres/index.html.erb</p>
+<h2>ジャンル一覧・追加<h2>
+
+<%= form_with model: @genre, url: admin_genres_path, method: :post, local: true do |f| %>
+<h4>ジャンル名<h4>
+<%= f.text_field :name %>
+<%= f.submit '新規登録' %>
+<% end %>
+
+<h4>ジャンル<h4>
+<% @genres.each do |genre| %>
+<%= genre.name %>
+<%= link_to '編集する', edit_admin_genre_path(genre.id) %>
+<% end %>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,2 +1,18 @@
-<h1>Admin::Items#new</h1>
-<p>Find me in app/views/admin/items/new.html.erb</p>
+<h2>商品新規登録<h2>
+<%= form_with model: @item, url: admin_items_path, method: :post, local: true do |f| %>
+<h4>商品画像<h4>
+<%= f.file_field :image, accept: 'image/*' %>
+<h4>商品名<h4>
+<%= f.text_field :name %>
+<h4>商品説明<h4>
+<%= f.text_area :intro %>
+<h4>ジャンル<h4>
+<%= f.select :genre_id, options_from_collection_for_select(@genre, :id, :name), { include_blank: "選択してください" } %>
+<h4>税抜価格<h4>
+<%= f.text_field :tax_free_price %>円
+<h4>販売ステータス<h4>
+  <%#= f.select :sale_status, [['販売停止中', true],['販売中', false]] %>
+  <%= f.radio_button :sale_status, :false %>　販売中
+  <%= f.radio_button :sale_status, :true %>　販売停止中
+<%= f.submit '新規登録' %>
+<% end %>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,2 +1,20 @@
-<h1>Admin::Items#show</h1>
-<p>Find me in app/views/admin/items/show.html.erb</p>
+<h2>商品詳細<h2>
+
+<%= image_tag @item.image, size: '300x200' %>
+
+<h4>商品名<h4>
+<%= @item.name %>
+
+<h4>商品説明<h4>
+<%= @item.intro %>
+
+<h4>ジャンル<h4>
+<%= @item.genre_id %>
+
+<h4>税込価格（税抜価格） %>
+<%#= @item.XXXXXXXXXX %>(<%= @item.tax_free_price %>)円
+
+<h4>販売ステータス<h4>
+<%= @item.sale_status %>
+
+<%#= link_to “編集する”, edit_admin_item_path(@item.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,59 +14,60 @@ devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
 }
 
   #会員側
-  
+
     root to: 'public/homes#top'
     # get 'homes/top'
-    
+
     get '/about' => 'public/homes#about'
-  
+
   scope module: :public do
     resources :shipping_addresses, only: [:index, :new, :show, :edit]
     # get 'shipping_addresses/index'
     # get 'shipping_addresses/edit'
-    
+
     get 'orders/completed' => 'orders#completed'
     resources :orders, only: [:new, :index, :show]
     # get 'orders/new'
     # get 'orders/index'
     # get 'orders/show'
-    
+
     # resource
     resource :cart_items, only: [:index]
     # get 'cart_items/index'
-    
+
     get 'customers/confirm'
     resources :customers, only: [:show, :edit,]
     # get 'customers/show'
     # get 'customers/edit'
-    
+
     resources :items, only: [:index, :show]
     # get 'items/index'
     # get 'items/show'
   end
-  
+
 
 
   #管理者側
 
   namespace :admin do
     get 'orders/show'
-    
+
     resources :customers, only: [:index, :show, :edit]
     # get 'customers/index'
     # get 'customers/show'
     # get 'customers/edit'
-    
+
     resources :genres, only: [:index, :create, :edit, :update]
     # get 'genres/index'
     # get 'genres/edit'
-    
-    resources :items, only: [:index, :new, :show, :edit]
+
+    # ほんたろ、createとupdate追加
+    resources :items, only: [:index, :new, :create, :show, :edit, :update]
     # get 'items/index'
     # get 'items/new'
     # get 'items/show'
     # get 'items/edit'
-    
+
     get 'homes/top'
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230518092850_add_genre_id_to_items.rb
+++ b/db/migrate/20230518092850_add_genre_id_to_items.rb
@@ -1,0 +1,5 @@
+class AddGenreIdToItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :items, :genre_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_17_073023) do
+ActiveRecord::Schema.define(version: 2023_05_18_092850) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2023_05_17_073023) do
     t.integer "tax_free_price"
     t.text "intro"
     t.boolean "sale_status", default: false
+    t.integer "genre_id"
   end
 
   create_table "order_details", force: :cascade do |t|


### PR DESCRIPTION
・genreのindexとeditの機能追加
・itemのnew(新規投稿)の機能追加
・「item.rb」「genre.rb」に１対多の記述（belongs_toやhas_many）を追加
・itemカラムに「genre.id」追加
・ルーティング変更（itemに"create"と"update"追加）
いずれもレイアウトは未完成です！
